### PR TITLE
Rediseño Selección de Variantes

### DIFF
--- a/users/__tests__/socket-handler.test.js
+++ b/users/__tests__/socket-handler.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import User from '../users-model.js';
 
 describe('Socket Handler', () => {
   let io;
@@ -21,10 +22,10 @@ describe('Socket Handler', () => {
   });
 
   beforeEach(() => {
-    vi.resetModules();
+    vi.restoreAllMocks();
 
-    findOneMock = vi.fn();
-    findByIdAndUpdateMock = vi.fn();
+    findOneMock = vi.spyOn(User, 'findOne');
+    findByIdAndUpdateMock = vi.spyOn(User, 'findByIdAndUpdate');
 
     io = {
       on: vi.fn((event, cb) => {
@@ -39,16 +40,8 @@ describe('Socket Handler', () => {
   });
 
   const setup = async () => {
-    vi.doMock('../users-model', () => ({
-      default: {
-        findOne: findOneMock,
-        findByIdAndUpdate: findByIdAndUpdateMock,
-      },
-      findOne: findOneMock,
-      findByIdAndUpdate: findByIdAndUpdateMock,
-    }));
-
-    const setupSocketHandler = (await import('../socket-handler.js')).default;
+    const imported = await import('../socket-handler.js');
+    const setupSocketHandler = imported.default || imported;
     setupSocketHandler(io);
   };
 
@@ -234,13 +227,13 @@ describe('Socket Handler', () => {
       .mockResolvedValueOnce({
         _id: 'u1',
         username: 'hostUser',
-        stats: {},
+        stats: { currentWinStreak: 2 },
         gameHistory: [],
       })
       .mockResolvedValueOnce({
         _id: 'u2',
         username: 'guestUser',
-        stats: {},
+        stats: { currentWinStreak: 5 },
         gameHistory: [],
       });
 
@@ -280,6 +273,38 @@ describe('Socket Handler', () => {
     await expect(
       socketHost.handlers['finishGame']({ code, winner: 'player0' })
     ).resolves.toBeUndefined();
+
+    expect(findByIdAndUpdateMock).toHaveBeenNthCalledWith(
+      1,
+      'u1',
+      expect.objectContaining({
+        $inc: expect.objectContaining({
+          'stats.gamesPlayed': 1,
+          'stats.gamesWon': 1,
+          'stats.totalMoves': 1,
+        }),
+        $set: {
+          'stats.currentWinStreak': 3,
+        },
+      }),
+      expect.any(Object)
+    );
+
+    expect(findByIdAndUpdateMock).toHaveBeenNthCalledWith(
+      2,
+      'u2',
+      expect.objectContaining({
+        $inc: expect.objectContaining({
+          'stats.gamesPlayed': 1,
+          'stats.gamesLost': 1,
+          'stats.totalMoves': 1,
+        }),
+        $set: {
+          'stats.currentWinStreak': 0,
+        },
+      }),
+      expect.any(Object)
+    );
   }, 100000);
 
   it('debería abandonar sala proactivamente (leaveRoom)', async () => {
@@ -312,7 +337,7 @@ describe('Socket Handler', () => {
     findOneMock.mockResolvedValueOnce({
       _id: 'u1',
       username: 'hostUser',
-      stats: {},
+      stats: { currentWinStreak: 4 },
       gameHistory: [],
     });
     findByIdAndUpdateMock.mockResolvedValue({});
@@ -364,6 +389,9 @@ describe('Socket Handler', () => {
           'stats.gamesAbandoned': 1,
           'stats.totalMoves': 1,
         }),
+        $set: {
+          'stats.currentWinStreak': 0,
+        },
       }),
       expect.any(Object)
     );
@@ -398,7 +426,7 @@ describe('Socket Handler', () => {
     findOneMock.mockResolvedValueOnce({
       _id: 'u2',
       username: 'guestUser',
-      stats: {},
+      stats: { currentWinStreak: 6 },
       gameHistory: [],
     });
     findByIdAndUpdateMock.mockResolvedValue({});
@@ -450,6 +478,9 @@ describe('Socket Handler', () => {
           'stats.gamesAbandoned': 1,
           'stats.totalMoves': 1,
         }),
+        $set: {
+          'stats.currentWinStreak': 0,
+        },
       }),
       expect.any(Object)
     );

--- a/users/__tests__/socket-handler.test.js
+++ b/users/__tests__/socket-handler.test.js
@@ -5,6 +5,8 @@ describe('Socket Handler', () => {
   let socketHost;
   let socketGuest;
   let connectionCallback;
+  let findOneMock;
+  let findByIdAndUpdateMock;
 
   const createSocketMock = (id) => ({
     id,
@@ -21,6 +23,9 @@ describe('Socket Handler', () => {
   beforeEach(() => {
     vi.resetModules();
 
+    findOneMock = vi.fn();
+    findByIdAndUpdateMock = vi.fn();
+
     io = {
       on: vi.fn((event, cb) => {
         if (event === 'connection') connectionCallback = cb;
@@ -34,6 +39,15 @@ describe('Socket Handler', () => {
   });
 
   const setup = async () => {
+    vi.doMock('../users-model', () => ({
+      default: {
+        findOne: findOneMock,
+        findByIdAndUpdate: findByIdAndUpdateMock,
+      },
+      findOne: findOneMock,
+      findByIdAndUpdate: findByIdAndUpdateMock,
+    }));
+
     const setupSocketHandler = (await import('../socket-handler.js')).default;
     setupSocketHandler(io);
   };
@@ -216,6 +230,22 @@ describe('Socket Handler', () => {
   });
 
   it('debería procesar finishGame sin errores', async () => {
+    findOneMock
+      .mockResolvedValueOnce({
+        _id: 'u1',
+        username: 'hostUser',
+        stats: {},
+        gameHistory: [],
+      })
+      .mockResolvedValueOnce({
+        _id: 'u2',
+        username: 'guestUser',
+        stats: {},
+        gameHistory: [],
+      });
+
+    findByIdAndUpdateMock.mockResolvedValue({});
+
     await setup();
     connectionCallback(socketHost);
     connectionCallback(socketGuest);
@@ -278,6 +308,67 @@ describe('Socket Handler', () => {
     expect(socketHost.leave).toHaveBeenCalledWith(code);
   });
 
+  it('debería guardar solo abandoned para el host si abandona la sala', async () => {
+    findOneMock.mockResolvedValueOnce({
+      _id: 'u1',
+      username: 'hostUser',
+      stats: {},
+      gameHistory: [],
+    });
+    findByIdAndUpdateMock.mockResolvedValue({});
+
+    await setup();
+    connectionCallback(socketHost);
+    connectionCallback(socketGuest);
+
+    const cbCreate = vi.fn();
+    socketHost.handlers['createRoom'](
+      {
+        size: 11,
+        mode: 'classic_hvh',
+        username: 'hostUser',
+        profilePicture: 'host.png',
+      },
+      cbCreate
+    );
+    const code = cbCreate.mock.calls[0][0].code;
+
+    socketGuest.handlers['joinRoom'](
+      { code, username: 'guestUser', profilePicture: 'guest.png' },
+      vi.fn()
+    );
+
+    socketHost.handlers['startGame']({
+      code,
+      gameId: 'game-2',
+      hostClientId: 'client-1',
+      extra: {},
+    });
+
+    socketHost.handlers['playMove']({ code, cellId: 3 });
+
+    await socketHost.handlers['leaveRoom']({ code });
+
+    expect(findOneMock).toHaveBeenCalledTimes(1);
+    expect(findOneMock).toHaveBeenCalledWith(
+      { username: 'hostUser' },
+      { username: 1, stats: 1, gameHistory: 1, _id: 1 }
+    );
+
+    expect(findByIdAndUpdateMock).toHaveBeenCalledTimes(1);
+    expect(findByIdAndUpdateMock).toHaveBeenCalledWith(
+      'u1',
+      expect.objectContaining({
+        $inc: expect.objectContaining({
+          'stats.gamesPlayed': 1,
+          'stats.gamesAbandoned': 1,
+          'stats.totalMoves': 1,
+        }),
+      }),
+      expect.any(Object)
+    );
+  }, 1000000);
+
   it('debería desconectar (disconnect) desde host', async () => {
     await setup();
     connectionCallback(socketHost);
@@ -302,4 +393,65 @@ describe('Socket Handler', () => {
       'El rival se ha desconectado de la partida.'
     );
   });
+
+  it('debería guardar solo abandoned para el guest si se desconecta', async () => {
+    findOneMock.mockResolvedValueOnce({
+      _id: 'u2',
+      username: 'guestUser',
+      stats: {},
+      gameHistory: [],
+    });
+    findByIdAndUpdateMock.mockResolvedValue({});
+
+    await setup();
+    connectionCallback(socketHost);
+    connectionCallback(socketGuest);
+
+    const cbCreate = vi.fn();
+    socketHost.handlers['createRoom'](
+      {
+        size: 11,
+        mode: 'classic_hvh',
+        username: 'hostUser',
+        profilePicture: 'host.png',
+      },
+      cbCreate
+    );
+    const code = cbCreate.mock.calls[0][0].code;
+
+    socketGuest.handlers['joinRoom'](
+      { code, username: 'guestUser', profilePicture: 'guest.png' },
+      vi.fn()
+    );
+
+    socketHost.handlers['startGame']({
+      code,
+      gameId: 'game-3',
+      hostClientId: 'client-1',
+      extra: {},
+    });
+
+    socketGuest.handlers['playMove']({ code, cellId: 8 });
+
+    await socketGuest.handlers['disconnect']();
+
+    expect(findOneMock).toHaveBeenCalledTimes(1);
+    expect(findOneMock).toHaveBeenCalledWith(
+      { username: 'guestUser' },
+      { username: 1, stats: 1, gameHistory: 1, _id: 1 }
+    );
+
+    expect(findByIdAndUpdateMock).toHaveBeenCalledTimes(1);
+    expect(findByIdAndUpdateMock).toHaveBeenCalledWith(
+      'u2',
+      expect.objectContaining({
+        $inc: expect.objectContaining({
+          'stats.gamesPlayed': 1,
+          'stats.gamesAbandoned': 1,
+          'stats.totalMoves': 1,
+        }),
+      }),
+      expect.any(Object)
+    );
+  }, 100000);
 });

--- a/users/socket-handler.js
+++ b/users/socket-handler.js
@@ -61,17 +61,29 @@ async function saveGameForUser(username, game) {
     "stats.totalMoves": game.totalMoves,
   };
 
-  if (game.result === "won")
+  const currentWinStreak = user.stats?.currentWinStreak || 0;
+  let nextWinStreak = 0;
+
+  if (game.result === "won") {
     inc["stats.gamesWon"] = 1;
-  else if (game.result === "lost")
+    nextWinStreak = currentWinStreak + 1;
+  }
+  else if (game.result === "lost") {
     inc["stats.gamesLost"] = 1;
-  else if (game.result === "abandoned")
+    nextWinStreak = 0;
+  }
+  else if (game.result === "abandoned") {
     inc["stats.gamesAbandoned"] = 1;
+    nextWinStreak = 0;
+  }
 
   await User.findByIdAndUpdate(
     user._id,
     {
       $inc: inc,
+      $set: {
+        "stats.currentWinStreak": nextWinStreak,
+      },
       $push: {
         gameHistory: {
           $each: [{

--- a/users/socket-handler.js
+++ b/users/socket-handler.js
@@ -102,26 +102,37 @@ async function persistRoomHistory(room, { hostResult, guestResult }) {
   room.historySaved = true;
 
   try {
-    await Promise.all([
-      saveGameForUser(room.hostUsername, {
-        gameId: room.gameId,
-        mode,
-        result: hostResult,
-        boardSize,
-        totalMoves: room.hostMoves || 0,
-        opponent: room.guestUsername || "Jugador online",
-        startedBy: "player0",
-      }),
-      saveGameForUser(room.guestUsername, {
-        gameId: room.gameId,
-        mode,
-        result: guestResult,
-        boardSize,
-        totalMoves: room.guestMoves || 0,
-        opponent: room.hostUsername || "Jugador online",
-        startedBy: "player0",
-      }),
-    ]);
+    const saves = [];
+
+    if (hostResult) {
+      saves.push(
+        saveGameForUser(room.hostUsername, {
+          gameId: room.gameId,
+          mode,
+          result: hostResult,
+          boardSize,
+          totalMoves: room.hostMoves || 0,
+          opponent: room.guestUsername || "Jugador online",
+          startedBy: "player0",
+        })
+      );
+    }
+
+    if (guestResult) {
+      saves.push(
+        saveGameForUser(room.guestUsername, {
+          gameId: room.gameId,
+          mode,
+          result: guestResult,
+          boardSize,
+          totalMoves: room.guestMoves || 0,
+          opponent: room.hostUsername || "Jugador online",
+          startedBy: "player0",
+        })
+      );
+    }
+
+    await Promise.all(saves);
   } catch (err) {
     room.historySaved = false;
     console.error('Error guardando historial multiplayer:', err);
@@ -276,12 +287,12 @@ module.exports = function setupSocketHandler(io) {
           if (socket.id === room.host) {
             await persistRoomHistory(room, {
               hostResult: 'abandoned',
-              guestResult: 'won',
+              guestResult: null,
             });
           }
           else if (socket.id === room.guest) {
             await persistRoomHistory(room, {
-              hostResult: 'won',
+              hostResult: null,
               guestResult: 'abandoned',
             });
           }
@@ -316,12 +327,12 @@ module.exports = function setupSocketHandler(io) {
             if (room.host === socket.id) {
               await persistRoomHistory(room, {
                 hostResult: 'abandoned',
-                guestResult: 'won',
+                guestResult: null,
               });
             }
             else {
               await persistRoomHistory(room, {
-                hostResult: 'won',
+                hostResult: null,
                 guestResult: 'abandoned',
               });
             }

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -24,7 +24,7 @@ import GameHoley from "./vistas/GameHoley";
 import GamePolyY from "./vistas/GamePolyY";
 import GameHex from "./vistas/GameHex";
 
-// ─── Flujo /home: selección de variante → configuración ─────────────────────
+// ─── Flujo /home: configuración → selección de variante ─────────────────────
 
 const CLASSIC_VARIANT: Variant = {
   id: "classic",
@@ -39,7 +39,7 @@ const CLASSIC_VARIANT: Variant = {
 };
 
 function HomeFlow() {
-  const [step, setStep] = useState<"variant" | "config">("variant");
+  const [step, setStep] = useState<"variant" | "config">("config");
   const [variant, setVariant] = useState<Variant>(CLASSIC_VARIANT);
 
   function handleVariantSelect(v: Variant) {
@@ -48,7 +48,7 @@ function HomeFlow() {
   }
 
   if (step === "variant") {
-    return <VariantSelect onSelect={handleVariantSelect} />;
+    return <VariantSelect onSelect={handleVariantSelect} onBack={() => setStep("config")} />;
   }
 
   return (

--- a/webapp/src/__tests__/Home.test.tsx
+++ b/webapp/src/__tests__/Home.test.tsx
@@ -71,7 +71,11 @@ vi.mock("antd", () => ({
             {children}
         </button>
     ),
-    Card: ({ children }: any) => <div data-testid="card">{children}</div>,
+    Card: ({ children, onClick, ...props }: any) => (
+        <div onClick={onClick} data-testid="card" {...props}>
+            {children}
+        </div>
+    ),
     Divider: ({ children }: any) => <div>{children}</div>,
     Flex: ({ children }: any) => <div>{children}</div>,
     Space: ({ children }: any) => <div>{children}</div>,
@@ -125,11 +129,8 @@ vi.mock("antd", () => ({
 vi.mock("@ant-design/icons", () => ({
     BuildOutlined: () => null,
     PlayCircleOutlined: () => null,
-    RobotOutlined: () => null,
     TeamOutlined: () => null,
-    ThunderboltOutlined: () => null,
-    FireOutlined: () => null,
-    ArrowLeftOutlined: () => null,
+    DeploymentUnitOutlined: () => null,
 }));
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -189,6 +190,28 @@ describe("Home", () => {
         renderHome();
 
         expect(await screen.findByTestId("app-header")).toHaveTextContent("YOVI");
+    });
+
+    it("renderiza la card de multijugador online", async () => {
+        metaOk();
+
+        renderHome();
+
+        expect(await screen.findByText("🌍 Multijugador Online (BETA)")).toBeInTheDocument();
+        expect(
+        screen.getByText(/Crea o únete a salas privadas mediante códigos y juega en tiempo real/i)
+        ).toBeInTheDocument();
+    });
+
+    it("navega a /multiplayer al pulsar la card de multijugador", async () => {
+        metaOk();
+
+        const user = userEvent.setup();
+        renderHome();
+
+        await user.click(await screen.findByText("🌍 Multijugador Online (BETA)"));
+
+        expect(navigateMock).toHaveBeenCalledWith("/multiplayer");
     });
 
     it("renderiza el nombre de la variante activa", async () => {

--- a/webapp/src/__tests__/VariantSelect.test.tsx
+++ b/webapp/src/__tests__/VariantSelect.test.tsx
@@ -6,16 +6,6 @@ import VariantSelect from "../vistas/VariantSelect";
 
 // ─── Mocks ───────────────────────────────────────────────────────────────────
 
-const navigateMock = vi.fn();
-
-vi.mock("react-router-dom", async () => {
-    const actual = await vi.importActual<any>("react-router-dom");
-    return {
-        ...actual,
-        useNavigate: () => navigateMock,
-    };
-});
-
 vi.mock("../vistas/AppHeader", () => ({
     default: ({ title }: { title: string }) => (
         <div data-testid="app-header">{title}</div>
@@ -52,15 +42,18 @@ vi.mock("@ant-design/icons", () => ({
 
 // ─── Helper ───────────────────────────────────────────────────────────────────
 
-function renderVariantSelect(onSelect = vi.fn()) {
-    return { onSelect, ...render(<VariantSelect onSelect={onSelect} />) };
+function renderVariantSelect(onSelect = vi.fn(), onBack = vi.fn()) {
+    return {
+        onSelect,
+        onBack,
+        ...render(<VariantSelect onSelect={onSelect} onBack={onBack} />),
+    };
 }
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe("VariantSelect", () => {
     beforeEach(() => {
-        navigateMock.mockReset();
         vi.restoreAllMocks();
     });
 
@@ -177,12 +170,12 @@ describe("VariantSelect", () => {
 
     // ── Botón Volver ─────────────────────────────────────────────────────────
 
-    it("el botón Volver navega a /", async () => {
+    it("el botón Volver llama a onBack", async () => {
         const user = userEvent.setup();
-        renderVariantSelect();
+        const { onBack } = renderVariantSelect();
 
         await user.click(screen.getByText("Volver"));
 
-        expect(navigateMock).toHaveBeenCalledWith("/");
+        expect(onBack).toHaveBeenCalledOnce();
     });
 });

--- a/webapp/src/vistas/Home.tsx
+++ b/webapp/src/vistas/Home.tsx
@@ -16,7 +16,7 @@ import {
   BuildOutlined,
   PlayCircleOutlined,
   TeamOutlined,
-  ArrowLeftOutlined,
+  DeploymentUnitOutlined
 } from "@ant-design/icons";
 import { useNavigate } from "react-router-dom";
 import { getMeta, type MetaResponse } from "../api/gamey";
@@ -269,6 +269,7 @@ export default function Home({ variant, onChangeVariant }: Props) {
         <div style={{ width: "min(1000px, 100%)" }}>
           <Space direction="vertical" size={16} style={{ width: "100%" }}>
             <AppHeader title="YOVI" />
+            <MultiplayerCard onClick={() => navigate("/multiplayer")} />
             <Card>
               <Space direction="vertical" size={16} style={{ width: "100%" }}>
                 <VariantHeader variant={variant} onChangeVariant={onChangeVariant} />
@@ -296,6 +297,7 @@ export default function Home({ variant, onChangeVariant }: Props) {
         <div style={{ width: "min(1000px, 100%)" }}>
           <Space direction="vertical" size={16} style={{ width: "100%" }}>
             <AppHeader title="YOVI" />
+            <MultiplayerCard onClick={() => navigate("/multiplayer")} />
             <Card>
               <Space direction="vertical" size={16} style={{ width: "100%" }}>
                 <VariantHeader variant={variant} onChangeVariant={onChangeVariant} />
@@ -323,6 +325,7 @@ export default function Home({ variant, onChangeVariant }: Props) {
       <div style={{ width: "min(1000px, 100%)" }}>
         <Space direction="vertical" size={16} style={{ width: "100%" }}>
           <AppHeader title="YOVI" />
+          <MultiplayerCard onClick={() => navigate("/multiplayer")} />
 
           <Card>
             <Space direction="vertical" size={16} style={{ width: "100%" }}>
@@ -386,6 +389,29 @@ export default function Home({ variant, onChangeVariant }: Props) {
   );
 }
 
+function MultiplayerCard({ onClick }: { onClick: () => void }) {
+  return (
+    <Card
+      hoverable
+      style={{
+        background: "linear-gradient(135deg, #1677ff 0%, #164cff 100%)",
+        border: "none",
+        color: "white",
+        textAlign: "center",
+        cursor: "pointer",
+      }}
+      onClick={onClick}
+    >
+      <Title level={3} style={{ color: "white", margin: 0 }}>
+        🌍 Multijugador Online (BETA)
+      </Title>
+      <Text style={{ color: "rgba(255,255,255,0.8)" }}>
+        Crea o únete a salas privadas mediante códigos y juega en tiempo real.
+      </Text>
+    </Card>
+  );
+}
+
 // ─── Subcomponentes reutilizables ─────────────────────────────────────────────
 
 function VariantHeader({
@@ -410,8 +436,8 @@ function VariantHeader({
         <Tag color={variant.tagColor}>{variant.tagLabel}</Tag>
       </Flex>
       <Button
-        size="small"
-        icon={<ArrowLeftOutlined />}
+        size="medium"
+        icon={<DeploymentUnitOutlined />}
         onClick={onChangeVariant}
         data-testid="change-variant-btn"
       >

--- a/webapp/src/vistas/MultiplayerLobby.tsx
+++ b/webapp/src/vistas/MultiplayerLobby.tsx
@@ -66,8 +66,8 @@ export default function MultiplayerLobby() {
       setLoading(false);
       if (res.success) {
         message.success("Unido correctamente");
-        navigate(`/multiplayer/${joinCode.trim().toUpperCase()}`, { 
-          state: { role: 'guest', config: res.roomConfig } 
+        navigate(`/multiplayer/${joinCode.trim().toUpperCase()}`, {
+          state: { role: "guest", config: res.roomConfig }
         });
       } else {
         message.error(res.error || "Error al unirse a la sala");
@@ -184,7 +184,7 @@ export default function MultiplayerLobby() {
 
           {!createdCode && (
             <Flex justify="flex-start">
-              <Button icon={<ArrowLeftOutlined />} onClick={() => navigate("/")}>
+              <Button icon={<ArrowLeftOutlined />} onClick={() => navigate("/home")}>
                 Volver al Menú
               </Button>
             </Flex>

--- a/webapp/src/vistas/VariantSelect.tsx
+++ b/webapp/src/vistas/VariantSelect.tsx
@@ -6,7 +6,6 @@ import {
   ArrowLeftOutlined,
   InfoCircleOutlined,
 } from "@ant-design/icons";
-import { useNavigate } from "react-router-dom";
 import AppHeader from "./AppHeader";
 
 const { Title, Text, Paragraph } = Typography;
@@ -158,10 +157,10 @@ export const DEFAULT_VARIANT = VARIANTS[0];
 
 type Props = {
   onSelect: (variant: Variant) => void;
+  onBack: () => void;
 };
 
-export default function VariantSelect({ onSelect }: Props) {
-  const navigate = useNavigate();
+export default function VariantSelect({ onSelect, onBack }: Props) {
   const [selected, setSelected] = useState<VariantId>("classic");
   const [expanded, setExpanded] = useState<VariantId | null>(null);
 
@@ -176,23 +175,6 @@ export default function VariantSelect({ onSelect }: Props) {
       <div style={{ width: "min(720px, 100%)" }}>
         <Space direction="vertical" size={16} style={{ width: "100%" }}>
           <AppHeader title="YOVI" />
-
-          <Card
-            hoverable
-            style={{ 
-              background: "linear-gradient(135deg, #1677ff 0%, #164cff 100%)",
-              border: "none",
-              color: "white",
-              textAlign: "center",
-              cursor: "pointer"
-            }}
-            onClick={() => navigate("/multiplayer")}
-          >
-            <Title level={3} style={{ color: "white", margin: 0 }}>🌍 Multijugador Online (BETA)</Title>
-            <Text style={{ color: "rgba(255,255,255,0.8)" }}>
-              Crea o únete a salas privadas mediante códigos y juega en tiempo real.
-            </Text>
-          </Card>
 
           <Card>
             <Space direction="vertical" size={20} style={{ width: "100%" }}>
@@ -320,7 +302,7 @@ export default function VariantSelect({ onSelect }: Props) {
               <Flex justify="space-between" align="center" wrap="wrap" gap={12}>
                 <Button
                   icon={<ArrowLeftOutlined />}
-                  onClick={() => navigate("/")}
+                  onClick={onBack}
                 >
                   Volver
                 </Button>

--- a/webapp/test/e2e/features/game.feature
+++ b/webapp/test/e2e/features/game.feature
@@ -1,16 +1,28 @@
 Feature: Juego Y
 
-  Scenario: Navegar a selección de variante
+  Scenario: Navegar a Home tras continuar sin cuenta
     Given estoy en la página de inicio
     When pulso "Continuar sin cuenta"
-    Then veo la pantalla de selección de variantes
+    Then veo la variante "YOVI"
     And veo la variante "Clásico"
+    And veo la variante "Human vs. Bot"
 
   Scenario: Configurar y empezar partida HvB clásica
-    Given estoy en la pantalla de configuración de la variante "classic"
-    When pulso el botón "Jugar" en la sección HvB
+    Given estoy en la página de inicio
+    When pulso "Continuar sin cuenta"
+    And pulso el botón "Jugar" en la sección HvB
     Then veo la pantalla de selección de dificultad
     And veo las opciones "Fácil", "Medio", "Difícil" y "Demencial"
+
+    Scenario: Estoy en Home y cambio el modo de juego a "Tabu"
+      Given estoy en la página de inicio
+      When pulso "Continuar sin cuenta"
+      And pulso "Cambiar variante"
+      Then veo la pantalla de selección de variantes
+      When pulso "Tabu Y"
+      And pulso "Continuar con «Tabu Y»"
+      Then veo la variante "Tabu Y"
+      And veo la variante "Human vs. Human"
 
   @skip
   Scenario: Seleccionar dificultad e iniciar partida

--- a/webapp/test/e2e/steps/game.steps.mjs
+++ b/webapp/test/e2e/steps/game.steps.mjs
@@ -117,7 +117,14 @@ When('selecciono la dificultad {string}', async function (label) {
 });
 
 When('pulso {string}', async function (texto) {
-  await this.page.click(`text="${texto}"`);
+  const button = this.page.getByRole('button', { name: texto }).first();
+
+  if (await button.count()) {
+    await button.click();
+    return;
+  }
+
+  await this.page.locator(`text=${texto}`).first().click();
 });
 
 Then('veo el tablero de juego', async function () {


### PR DESCRIPTION
- Se ha movido la vista para seleccionar la variante de juego para tener un flujo más "limpio" y consistente. 
  - Antes, para poder acceder a Home con la configuración del juego (tamaño del tablero, primer jugador, etc), había que pasar primero por VariantSelect y escoger el modo de juego.
  - Ahora se redirige siempre a Home, escogiendo por defecto el modo Clásico. Para cambiar la variante, se puede acceder como antes mediante el botón.
  - Además la opción multijugador se ha movido a la vista Home, quitándola de VariantSelect, para hacerla más accesible.

<img width="60%" height="auto" alt="image" src="https://github.com/user-attachments/assets/d835f745-9c89-400e-afb5-6ddb7c7af3ae" />

- También se ha refactorizado el "layout" de VariantSelect para cambiarlo por el componente Masonry de Ant Design, haciendo está página más visual.

<img width="60%" height="auto" alt="image" src="https://github.com/user-attachments/assets/4ea47270-9d8b-43f0-b000-c26282219cdc" />

- Por último se han arreglado dos pequeños bugs que ocurrían con el juego Multiusuario:
  - Cuando uno de los jugadores abandonaba o se desconectaba de la partida, antes se guardaba para el otro jugador la partida como ganada. Ahora ya está solucionado y directamente a este otro jugador no se almacena la partida en el historial (al jugador que abandona/se desconecta si se le guarda como "abandoned").
  - La racha de partidas consecutivas ganadas no se actualizaba cuando se perdía o se abandonaba en el modo multijugador. Ahora ya está corregido y la racha se actualiza en todos los casos.